### PR TITLE
Add Audexum to the commercial TTS platforms table

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Leading platforms offering robust, scalable, and high-quality Text-to-Speech API
 | **Spokio** | Spokio | Offline macOS text-to-speech app with local voice cloning, batch export, and no cloud uploads. | **Free** (API Credits) / Enterprise | **<$1M** (Indie) | [Spokio](https://spokio.pro/) |
 | **PHANTOM VOICES** | PHANTOM VOICES | 10 free professional AI voice clones via public REST API. Zero cost, commercial rights cleared. 29 platform configs (Vapi, Retell AI, etc). Multilingual (9+ languages). AI-powered recommendation. | **Free** (API Credits) / Enterprise | **<$1M** (Indie) | [PHANTOM VOICES](https://auto-business-agent.replit.app/portfolio) |
 | **RunAPI ElevenLabs SDK** | RunAPI | Multi-language SDKs for ElevenLabs text-to-speech, dialogue generation, sound effects, transcription, and audio isolation workflows. | Pay-as-you-go | **<$1M** (Indie) | [RunAPI ElevenLabs SDK](https://github.com/runapi-ai/elevenlabs-sdk) |
+| **Audexum** | Audexum | Text-to-speech and speech-to-text in one API: 43 voices, 32 TTS languages, 25 STT languages. ElevenLabs-compatible endpoint, so switching is a base-URL change. EU-hosted, every output watermarked. | **Free** (30k credits at signup, 3k/mo after) / EUR 4 | **<$1M** (Indie) | [Audexum](https://audexum.com/docs) |
 
 ### 🏗️ Open-Source Text-to-Speech Libraries & Local-First Projects
 


### PR DESCRIPTION
Adding Audexum to the `<$1M (Indie)` block at the end of the commercial platforms table.

| Field | Value |
| --- | --- |
| Service | Audexum |
| Key features | Text-to-speech **and** speech-to-text behind one API — 43 voices, 32 TTS languages, 25 STT languages. ElevenLabs-compatible endpoint (`POST /v1/text-to-speech/{voice_id}`, `GET /v1/voices`), so an existing integration switches by changing the base URL. EU-hosted, every output watermarked. |
| Min. monthly | Free — 30,000 credits at signup, 3,000/month after — then EUR 4 |
| Company size | <$1M (Indie) |
| Link | https://audexum.com/docs |

Two things that may be worth the row given what is already in the table: most entries here are TTS-only, and none of the indie ones are drop-in compatible with an existing ElevenLabs integration. The watermarking is AudioSeal and it fails closed, which is what EU AI Act Article 50 disclosure asks for.

Disclosure: I maintain Audexum, and this PR was drafted with an AI assistant. Happy to reword, shorten, or move the row if the placement or tone is off.