### PR TITLE
fix: broken nav anchor, Coqui TTS shutdown note, and ttsproof link syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Welcome to the most comprehensive, meticulously curated, and continuously update
 ## 🗺️ Quick Navigation
 
 - [Why Text-to-Speech?](#-why-explore-text-to-speech)
-- [Current Trends (2026)](#-current-state-of-text-to-speech-as-of-2024-)
+- [Current Trends (2026)](#-current-state-of-text-to-speech-2026-update)
 - [Commercial & Cloud Platforms](#-cloud-based--commercial-ai-voice-generation-platforms)
 - [Open-Source Libraries](#-open-source-text-to-speech-libraries--projects)
 - [Advanced Voice Cloning](#-advanced-voice-cloning--neural-voice-synthesis-)
@@ -107,7 +107,7 @@ If you are looking for **free text-to-speech models for commercial use** or want
 
 | 🛠️ Service/Model | 🏢 Organization | 🌟 Key Features | 🗣️ Primary Language | 📁 Github_Repository |
 | --- | --- | --- | --- | --- |
-| **🐸 Coqui TTS** | Coqui | **Best overall open-source TTS.** Supports 1100+ languages, zero-shot voice cloning, and fine-tuning. | Python / Multilingual | [![GitHub stars](https://img.shields.io/github/stars/coqui-ai/TTS?style=social&color=white)](https://github.com/coqui-ai/TTS/stargazers) |
+| **🐸 Coqui TTS** | Coqui (community) | Supports 1100+ languages, zero-shot voice cloning, and fine-tuning. *Note: Coqui AI (the company) shut down in late 2023; actively maintained by the community at [idiap/coqui-ai-TTS](https://github.com/idiap/coqui-ai-TTS).* | Python / Multilingual | [![GitHub stars](https://img.shields.io/github/stars/coqui-ai/TTS?style=social&color=white)](https://github.com/coqui-ai/TTS/stargazers) |
 | **GPT-SoVITS** | RVC-Boss | **Zero-shot & few-shot voice cloning.** Requires only 5 seconds of sample audio for cross-lingual synthesis. | Python / PyTorch | [![GitHub stars](https://img.shields.io/github/stars/RVC-Boss/GPT-SoVITS?style=social&color=white)](https://github.com/RVC-Boss/GPT-SoVITS/stargazers) |
 | **Bark** | Suno | Transformer-based text-to-audio model capable of highly expressive speech, music, laughs, and sighs. | Python / PyTorch | [![GitHub stars](https://img.shields.io/github/stars/suno-ai/bark?style=social&color=white)](https://github.com/suno-ai/bark/stargazers) |
 | **ChatTTS** | 2noise | Conversational text-to-speech model specially optimized for dialogue and natural conversational flow. | Python | [![GitHub stars](https://img.shields.io/github/stars/2noise/ChatTTS?style=social&color=white)](https://github.com/2noise/ChatTTS/stargazers) |
@@ -179,7 +179,7 @@ Stay updated with the latest breakthroughs and discussions in the TTS community.
 -   **[Reddit: The ElevenLabs Killer Quest (r/TTS)](https://www.reddit.com/r/TTS/):** Community-driven search for high-fidelity, local open-source alternatives to proprietary SaaS.
 -   **[TTS Arena by Artificial Analysis](https://artificialanalysis.ai/models/speech):** The definitive community leaderboard for blind-testing the naturalness of modern TTS models.
 -   **[[D] Why Flow Matching is replacing traditional Diffusion in TTS](https://www.reddit.com/r/MachineLearning/):** Technical deep-dive into the "straightening" of ODE paths for faster, higher-quality audio generation.
--   **[An Automated Failure-Mode QA Framework for Neural Text-to-Speech Systems](https://doi.org/10.5281/zenodo.20757553):** A production case study introducing automated failure-mode detection for TTS output, with [ttsproof (https://github.com/Mormolykos/ttsproof) as its open-source implementation.
+-   **[An Automated Failure-Mode QA Framework for Neural Text-to-Speech Systems](https://doi.org/10.5281/zenodo.20757553):** A production case study introducing automated failure-mode detection for TTS output, with [ttsproof](https://github.com/Mormolykos/ttsproof) as its open-source implementation.
 
 ### Exemplary Code Samples & Project Demos 💻
 


### PR DESCRIPTION
## Summary

This PR fixes three small but impactful issues in the README:

### 1. 🔗 Broken Quick Navigation Anchor (Line 34)
The **Current Trends (2026)** nav link pointed to `#-current-state-of-text-to-speech-as-of-2024-` but the actual heading is **Current State of Text-to-Speech (2026 Update)**. Clicking the link didn't scroll to the correct section. Fixed the anchor to match the heading.

### 2. 🐸 Coqui TTS — Company Shutdown Note (Line 110)
**Coqui AI** (the company) [shut down in late 2023](https://www.reddit.com/r/MachineLearning/comments/17mfdlq/d_coqui_the_startup_behind_coqui_tts_has_shut/). The entry previously called it *Best overall open-source TTS* without any context about the company status. Updated to:
- Note the company shutdown
- Link to the **actively maintained community fork** at [idiap/coqui-ai-TTS](https://github.com/idiap/coqui-ai-TTS) (2,300+ ⭐)

### 3. 📝 Broken Markdown Link — ttsproof (Line 182)
The `ttsproof` link had mismatched brackets: `[ttsproof (https://...)` instead of `[ttsproof](https://...)`, which rendered as broken text instead of a clickable link.

---

**No new entries added, no content removed** — just accuracy and link fixes to keep this excellent resource up to date. 🙏